### PR TITLE
Add a non-empty captureDir

### DIFF
--- a/main.py
+++ b/main.py
@@ -334,7 +334,7 @@ class trunk_recorder_helper:
         ],
         "systems": [           
         ],
-        "captureDir": "",
+        "captureDir": "captures",
         "logLevel": "info",
         "broadcastSignals": True,
         "frequencyFormat": "mhz",


### PR DESCRIPTION
In the latest trunk-recorder v5, a config with a captureDir with an empty string results in a cryptic error:

```
Failed parsing Config: basic_string::erase: __pos (which is 18446744073709551615) > this->size() (which is 0)
```

It's such a confusing error, that it took me a few minutes to track down which config directive was to blame. Setting captureDir to any non-empty value will solve things.